### PR TITLE
Add module for working with Yaml

### DIFF
--- a/nim_utils.nimble
+++ b/nim_utils.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.17"
+version       = "0.2.0"
 author        = "Thomas Nelson"
 description   = "A collection of functions I've written in other projects and want to reuse."
 license       = "Unlicense"
@@ -9,6 +9,7 @@ srcDir        = "src"
 
 # Dependencies
 requires "nim >= 1.6.6"
+requires "yaml"
 
 task test, "Runs the test suite":
   exec "nimble install -y && testament p 'tests/*.nim'"

--- a/src/nim_utils/simple_yaml.nim
+++ b/src/nim_utils/simple_yaml.nim
@@ -1,0 +1,203 @@
+import
+    sequtils,
+    streams,
+    strformat,
+    strutils,
+    sugar,
+    tables,
+    yaml,
+    yaml/dom
+
+type
+  YNodeKind* = enum
+    ynString, ynList, ynMap
+  YNode* = object
+    case kind*: YNodeKind
+    of ynString:
+      strVal*: string
+    of ynList:
+      listVal*: seq[YNode]
+    of ynMap:
+      mapVal*: TableRef[string, YNode]
+
+proc newYList*(elems: seq[YNode]): YNode =
+    YNode(kind:ynList, listVal: elems)
+
+proc newYMap*(t: TableRef[string,YNode]): YNode =
+    YNode(kind: ynMap, mapVal: t)
+
+proc newYMap*(a: openArray[(string,YNode)]): YNode =
+    a.newTable().newYMap()
+
+proc newYString*(s: string): YNode =
+    YNode(kind: ynString, strVal: s)
+
+proc newYList*(elems: seq[string]): YNode =
+    YNode(kind:ynList, listVal: elems.map(newYString))
+
+template expectYString*(body: untyped) =
+    case n.kind
+    of ynString:
+        body
+    else:
+        raise newException(ValueError, "expected string YNode")
+
+template expectYList*(body: untyped) =
+    case n.kind
+    of ynList:
+        body
+    else:
+        raise newException(ValueError, "expected list YNode")
+
+template expectYMap*(body: untyped) =
+    case n.kind
+    of ynMap:
+        body
+    else:
+        raise newException(ValueError, "expected map YNode")
+
+proc get*(n: YNode, k: string): YNode =
+    expectYMap:
+        result = n.mapVal[k]
+
+proc elems*(n: YNode): seq[YNode] =
+    expectYList:
+        result = n.listVal
+
+proc str*(n: YNode): string =
+    expectYString:
+        result = n.strVal
+
+proc getStr*(n: YNode, k: string): string =
+    expectYMap:
+        n.get(k).str()
+
+proc toInt*(n: YNode): int =
+    expectYString:
+        result = parseInt(n.strVal)
+
+proc toFloat*(n: YNode): float =
+    expectYString:
+        result = parseFloat(n.strVal)
+
+proc simplifyName(k: YamlNode): string =
+  case k.kind
+  of yScalar:
+    return k.content
+  else:
+    raise newException(ValueError, "Cannot simplify the name of a non-scalar")
+
+proc translate(n: YamlNode): YNode =
+  case n.kind
+  of yMapping:
+    let t = newTable[string,YNode](n.fields.len)
+    for k,v in n.fields.pairs:
+      let name = simplifyName(k)
+      t[name] = translate(v)
+    result = newYMap(t)
+  of ySequence:
+    let elems = n.elems.mapIt(translate(it))
+    result = newYList(elems)
+  else:
+    result = newYString(n.content)
+
+proc loadNode*(s: string | Stream): YNode =
+    var node: YamlNode
+    load(s,node)
+    return translate(node)
+
+proc newline(i: int): string =
+    "\n" & repeat(' ', i)
+
+proc toString*(n: YNode, indentLevel=0): string =
+
+    proc newline(): string =
+        newline(indentLevel)
+
+    case n.kind
+    of ynString:
+        let s = n.strVal
+        if len(s) > 0:
+            return s
+        else:
+            return "\"\""
+    of ynMap:
+        let fields = n.mapVal
+        let s = collect:
+            for k,v in fields.pairs:
+                case v.kind
+                of ynString:
+                    let newIndent = indentLevel + len(k) + 2
+                    let vstr = v.toString(indentLevel=newIndent)
+                    fmt"{k}: {vstr}"
+                else:
+                    let newIndent = indentLevel+2
+                    let vstr = v.toString(indentLevel=newIndent)
+                    fmt"{k}:{newline(newIndent)}{vstr}"
+        case len(s)
+        of 0:
+            return "{}"
+        else:
+            return s.join(newline())
+    of ynList:
+        let elems = n.listVal
+        case len(elems)
+        of 0: 
+            return "[]"
+        else:
+            return elems
+                .mapIt(toString(it,indentLevel=indentLevel+2))
+                .mapIt("- $1" % it)
+                .join(newline())
+
+proc toYaml*(s: string): YNode =
+    newYString(s)
+
+proc toYaml*(i: int): YNode =
+    newYString($i)
+
+proc toYaml*(f: float): YNode =
+    newYString($f)
+
+proc toYaml*(b: bool): YNode =
+    newYString($b)
+
+proc toYaml*[T](l: seq[T]): YNode =
+    let elems = collect:
+        for x in l:
+            toYaml(x)
+    return elems.newYList()
+
+proc ofYaml*[T](n: YNode, t: typedesc[T]): T =
+    discard
+
+proc ofYaml*[T](n: YNode, t: typedesc[seq[T]]): seq[T] =
+    expectYList:
+        result = collect:
+            for x in n.elems():
+                ofYaml(x, T)
+
+proc ofYaml*(n: YNode, t: typedesc[int]): int =
+    n.toInt()
+
+proc ofYaml*(n: YNode, t: typedesc[float]): float =
+    n.toFloat()
+
+proc ofYaml*(n: YNode, t: typedesc[string]): string =
+    n.str()
+
+proc `==`*(a: YNode, b: YNode): bool =
+    if a.kind != b.kind:
+        return false
+    else:
+        case a.kind
+        of ynString:
+            return a.strVal == b.strVal
+        of ynList:
+            let la = a.elems()
+            let lb = b.elems()
+            return la == lb
+        of ynMap:
+            let ma = a.mapVal
+            let mb = b.mapVal
+            return ma == mb

--- a/tests/test_utils/yaml_testing.nim
+++ b/tests/test_utils/yaml_testing.nim
@@ -1,0 +1,25 @@
+import
+    nim_utils/simple_yaml {.all.}
+
+import
+    tables,
+    unittest
+
+const divider* = "\n~~~~~~~~~~~~\n"
+template echod*(s) =
+  echo s
+  echo divider
+
+proc roundTrip*(n: YNode): YNode =
+    n.toString().loadNode()
+
+proc checkRoundTrip*(n: YNode) =
+    check n == roundTrip(n)
+
+proc checkRoundTrip*[T](x: T) =
+    let n = toYaml(x)
+    checkRoundTrip n
+
+proc checkRoundTrip*(s: string) =
+    let n = s.loadNode()
+    checkRoundTrip n

--- a/tests/tyaml.nim
+++ b/tests/tyaml.nim
@@ -1,0 +1,127 @@
+import 
+  std/tables,
+  unittest
+
+import 
+  nim_utils/simple_yaml {.all.}
+
+import
+  test_utils/yaml_testing
+
+let sampleNodeStr = """
+{ "i": 1, "f": 0.1, "s": "hello"}
+"""
+checkRoundTrip sampleNodeStr
+
+var mynode: YNode 
+mynode = loadNode(sampleNodeStr)
+checkRoundTrip mynode
+check mynode.kind == ynMap
+check mynode.mapVal.len() == 3
+check mynode.get("i").toInt() == 1
+check mynode.get("f").toFloat() == 0.1
+check mynode.get("s").str() == "hello"
+
+var sampleStr = """
+a:
+- 1
+- 2
+- 3
+b: false
+"""
+checkRoundTrip sampleStr
+
+mynode = loadNode(sampleStr)
+checkRoundTrip mynode
+check mynode.kind == ynMap
+check mynode.mapVal.len() == 2
+let a = mynode.get("a")
+check a.kind == ynList
+check a.elems().len() == 3
+check a.elems()[0].str() == "1"
+check mynode.get("b").kind == ynString
+
+let intList: YNode = newYList(@[
+    newYString("1"), 
+    newYString("2"), 
+    newYString("3")
+])
+
+checkRoundTrip intList
+
+let heteroList: YNode = newYList(@[
+  newYString("1"), 
+  newYString("2"), 
+  newYList(@[newYString("3"), newYString("4")]),
+  newYString("5")
+])
+checkRoundTrip heteroList
+
+
+let smallList: YNode = newYList(@["a", "b", "c", "d"])
+checkRoundTrip smallList
+
+let t = {
+  "x": smallList, 
+  "y": newYString("yay"),
+  "z": heteroList,
+  "z2": heteroList,
+}.newTable()
+
+let mapExample: YNode = newYMap(t)
+checkRoundTrip mapExample
+
+let t2 = {
+  "apple": newYString("red"),
+  "orange": heteroList,
+  "banana": mapExample
+}.newTable()
+
+let map2: YNode = newYMap(t2)
+checkRoundTrip map2
+
+
+# Check Maps under lists
+let map3 = newYMap({
+  "example1": newYList(@[newYString("0.12"), map2]),
+  "example2": mapExample
+})
+
+checkRoundTrip map3
+
+var s = """
+a: 1
+b: 2
+c: 
+  d: 4
+  e: 5
+  f: 
+   - 6
+   - 7
+   - 8
+"""
+checkRoundTrip s
+
+# Empty list
+let emptyNodes: seq[YNode] = @[]
+let emptyList = newYList(emptyNodes)
+checkRoundTrip emptyList
+let emptyList2 = emptyList.toString().loadNode()
+assert emptyList2.kind == ynList
+assert emptyList2.listVal.len() == 0
+
+# empty map
+let emptyMap = newYMap(newTable[string,YNode]())
+checkRoundTrip emptyMap
+let emptyMap2 = emptyMap.toString().loadNode()
+checkRoundTrip emptyMap2
+assert emptyMap2.kind == ynMap
+assert emptyMap2.mapVal.len() == 0
+
+# empty string
+let emptyString = newYString("")
+checkRoundTrip emptyString
+let emptyStringList = newYList(@[emptyString, emptyString])
+checkRoundTrip emptyStringList
+let emptyStringMap = newYMap({"a": emptyString, "b": newYString("1")})
+checkRoundTrip emptyStringMap

--- a/tests/tyaml_extension.nim
+++ b/tests/tyaml_extension.nim
@@ -1,0 +1,150 @@
+import
+    strformat,
+    tables,
+    unittest
+
+import
+    nim_utils/simple_yaml {.all.}
+
+import
+  test_utils/yaml_testing
+
+type 
+  MountKind* = enum
+    mkTmpfs = "tmpfs"
+    mkS3fs = "s3fs"
+  Mount* = object
+    mountPoint: string
+    name: string
+    case kind: MountKind
+    of mkTmpfs:
+      discard
+    of mkS3fs:
+      key: string
+      secret: string
+      bucket: string
+  Con* = object of RootObj
+    name*: string
+    mounts*: seq[Mount]
+
+proc ofYaml(n: YNode, t: typedesc[MountKind]): MountKind =
+    expectYString:
+        case n.strVal
+        of $mkTmpfs:
+            mkTmpfs
+        of $mkS3fs:
+            mkS3fs
+        else:
+            raise newException(ValueError, fmt"unknown kind {n.strVal}")
+
+
+proc ofYaml(n: YNode, t: typedesc[Mount]): Mount =
+    expectYMap:
+        let kind = ofYaml(n.get("kind"), MountKind)
+        let mountPoint = n.get("mountPoint").str()
+        let name = n.getStr("name")
+        case kind
+        of mkS3fs:
+            let key = n.get("key").str()
+            let secret = n.getStr("secret")
+            let bucket = n.getStr("bucket")
+            result = Mount(kind: kind,
+                           mountPoint: mountPoint, 
+                           key: key, 
+                           secret: secret, 
+                           bucket: bucket, 
+                           name: name)
+        of mkTmpfs:
+            result = Mount(kind: kind,
+                           mountPoint: mountPoint, 
+                           name: name)
+
+proc ofYaml(n: YNode, t: typedesc[Con]): Con =
+    expectYMap:
+        let name = n.getStr("name")
+        let mounts: seq[Mount] = ofYaml(n.get("mounts"), seq[Mount])
+        return Con(name: name, mounts: mounts)
+
+proc toYaml(m: Mount): YNode =
+    let common = {
+        "kind": toYaml($m.kind),
+        "mountPoint": toYaml(m.mountPoint),
+        "name": toYaml(m.name)
+    }
+    var extra: seq[(string,YNode)]
+    case m.kind
+    of mkTmpfs:
+        extra = @[]
+    of mkS3fs:
+        extra = @[ 
+            ("key", toYaml(m.key)),
+            ("secret", toYaml(m.secret)),
+            ("bucket", toYaml(m.bucket))
+        ]
+    let t = newTable[string,YNode]()
+    for _,(k,v) in common:
+        t[k] = v
+    for _,(k,v) in extra:
+        t[k] = v
+
+    return newYMap(t)
+
+
+proc toYaml(c: Con): YNode =
+    {
+     "name": toYaml(c.name),
+     "mounts": toYaml(c.mounts)
+    }.newYMap()
+
+let noMounts = Con(name:"example", mounts: @[])
+
+let m = Mount(mountPoint: "/etc/tmpfs", kind: mkTmpfs, name: "tmp")
+
+var c2 = Con(name: "c2", mounts: @[m])
+
+echod m.toYaml().toString()
+
+echod noMounts.toYaml().toString()
+echod c2.toYaml().toString()
+
+let cy: YNode = c2.toYaml()
+
+let m2 = ofYaml(m.toYaml(), Mount)
+check m2.name == m.name
+check m2.mountPoint == m.mountPoint
+check m2.kind == m.kind
+checkRoundTrip m2
+
+
+let c3: Con = ofYaml(cy, Con)
+check c3.name == c2.name
+check len(c3.mounts) == 1
+check c3.mounts[0].name == m2.name
+checkRoundTrip c3
+
+checkRoundTrip cy
+
+# var s = newFileStream("out.yaml", fmWrite)
+# dump(noMounts, s)
+# s.close()
+
+# s = newFileStream("out2.yaml", fmWrite)
+# dump(c2,s)
+# s.close()
+
+# import std/typeinfo
+
+# var x: Any
+
+# x = c2.toAny
+
+# # echo x.kind
+# # for (name,i) in x.fields:
+# #   echo name
+
+# import macros
+
+# macro dumpTypeImpl(x: typed): untyped =
+#   newLit(x.getTypeImpl.repr)
+
+# # echo c2.dumpTypeImpl()


### PR DESCRIPTION
Working with NimYAML is unpleasant due to the number of tags that it spits out in output and due to the APIs not matching how I wanted to use them.

This module currently still uses NimYAML for parsing, but provides a YNode type to work with Yaml objects at runtime and an alternate toString() serialization proc.

Future expansions:
  code generation for ofYaml/toYaml based on type information
    - should support polymorphism and variants